### PR TITLE
Get data

### DIFF
--- a/include/SuMo.h
+++ b/include/SuMo.h
@@ -93,8 +93,8 @@ class SuMo{
   int  make_count_to_voltage(void);                     //make count-to-voltage LUT for each active board (# active boards * 6 channels * 1536 cells * 4096 !!)
   int  make_count_to_voltage(bool COPY, bool* range);
   int  load_ped();
-  std::vector<packet_t>* get_data(unsigned int NUM_READS, int trig_mode, int acq_rate);
-  int log_data(const char* log_filename, std::vector<packet_t>* event_data);
+  std::vector<packet_t*>* get_data(unsigned int NUM_READS, int trig_mode, int acq_rate);
+  int log_data(const char* log_filename, std::vector<packet_t*>* event_data, int trig_mode);
 
 
   int  check_active_boards(void);

--- a/include/SuMo.h
+++ b/include/SuMo.h
@@ -13,6 +13,7 @@ author: eric oberla
 #include <stdio.h>
 #include <unistd.h>
 #include <time.h>
+#include <vector>
 
 #include "stdUSB.h"
 #include "Definitions.h"
@@ -92,7 +93,9 @@ class SuMo{
   int  make_count_to_voltage(void);                     //make count-to-voltage LUT for each active board (# active boards * 6 channels * 1536 cells * 4096 !!)
   int  make_count_to_voltage(bool COPY, bool* range);
   int  load_ped();
-  int  log_data(const char* log_filename, unsigned int NUM_READS, int trig_mode, int acq_rate);
+  std::vector<packet_t>* get_data(unsigned int NUM_READS, int trig_mode, int acq_rate);
+  int log_data(const char* log_filename, std::vector<packet_t>* event_data);
+
 
   int  check_active_boards(void);
   int  check_active_boards(bool print);

--- a/include/SuMo.h
+++ b/include/SuMo.h
@@ -93,8 +93,8 @@ class SuMo{
   int  make_count_to_voltage(void);                     //make count-to-voltage LUT for each active board (# active boards * 6 channels * 1536 cells * 4096 !!)
   int  make_count_to_voltage(bool COPY, bool* range);
   int  load_ped();
-  std::vector<packet_t*>* get_data(unsigned int NUM_READS, int trig_mode, int acq_rate);
-  int log_data(const char* log_filename, std::vector<packet_t*>* event_data, int trig_mode);
+  std::vector<packet_t**> get_data(unsigned int NUM_READS, int trig_mode, int acq_rate);
+  int log_data(const char* log_filename, std::vector<packet_t**> event_data, int trig_mode);
 
 
   int  check_active_boards(void);

--- a/src/logData.cpp
+++ b/src/logData.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]){
     if(command.check_active_boards(num_checks))
     return 1;
 
-    events = command.get_data(num_events, trig_mode, 0)
+    vector<packet_t>* events = command.get_data(num_events, trig_mode, 0);
     command.log_data(log_data_filename, events);
 
     return 0;

--- a/src/logData.cpp
+++ b/src/logData.cpp
@@ -78,7 +78,11 @@ vector<packet_t>* SuMo::get_data(unsigned int NUM_READS, int trig_mode, int acq_
 
   load_ped();
 
+  int number_of_frontend_cards = 0;
 
+  for( int board = 0; board < numFrontBoards; board++){
+    if(DC_ACTIVE[board]) number_of_frontend_cards++;
+  }
 
   cout << "--------------------------------------------------------------" << endl;
   cout << "number of front-end boards detected = " << number_of_frontend_cards
@@ -283,7 +287,7 @@ vector<packet_t>* SuMo::get_data(unsigned int NUM_READS, int trig_mode, int acq_
   return events;
 }
 
-int SuMo::log_data(const char* log_filename, vector<packet_t>* event_data){
+int SuMo::log_data(const char* log_filename, vector<packet_t>* event_data, int trig_mode){
   char logDataFilename[300];
   int numEvents = sizeof(event_data[0])/sizeof(event_data[0][0]);
   // 'scalar' mode


### PR DESCRIPTION
This takes the log_data member function of SuMo and breaks into 2 functions: get_data and log_data. This will take us closer to creating a library framework. The current data structure for getting data is a vector of packet_t pointer arrays. The vector serves to contain data for every event that happens. Each event is a packet_t pointer array with a pointer for each frontend board. This plug and plays very well with Eric's code.  

I have tested this by using the logData command to take data and compared its output to the output from the logData command prior to separation. Although I cannot confirm that all functionality is equivalent, I am confident that the logs were of similar structure and usage.